### PR TITLE
adds NUMROWS parameter to data command

### DIFF
--- a/src/gle/glearray.cpp
+++ b/src/gle/glearray.cpp
@@ -339,6 +339,7 @@ GLECSVData::GLECSVData() {
 	initDelims();
 	m_lines = 0;
 	m_ignoreHeader = 0;
+	m_numrows = 0;
 	m_nextLine = true;
 	m_firstColumn = 0;
 	m_error.errorCode = GLECSVErrorNone;
@@ -499,6 +500,9 @@ void GLECSVData::parseBlock() {
 	GLECSVDataStatus status = ignoreHeader();
 	while (status != GLECSVDataStatusEOF) {
 		status = readCell();
+		if (m_nextLine && m_numrows && (m_firstCell.size() >= m_numrows)) {
+			break;
+		}
 	}
 }
 
@@ -521,6 +525,10 @@ void GLECSVData::setCommentIndicator(const char* comment) {
 
 void GLECSVData::setIgnoreHeader(unsigned int ignore) {
 	m_ignoreHeader = ignore;
+}
+
+void GLECSVData::setNumrows(signed int numrows) {
+	m_numrows = numrows;
 }
 
 void GLECSVData::initDelims() {

--- a/src/gle/glearray.h
+++ b/src/gle/glearray.h
@@ -153,6 +153,7 @@ protected:
 	unsigned int m_firstColumn;
 	unsigned int m_nextLine;
 	unsigned int m_ignoreHeader;
+	unsigned int m_numrows;
 	GLECSVError m_error;
 	string m_fileName;
 	string m_comment;
@@ -166,6 +167,7 @@ public:
 	void setDelims(const char* delims);
 	void setCommentIndicator(const char* comment);
 	void setIgnoreHeader(unsigned int ignore);
+	void setNumrows(signed int numrows);
 	GLECSVError* getError();
 	unsigned int getNbLines();
 	unsigned int getNbColumns(unsigned int line);

--- a/src/gle/graph.cpp
+++ b/src/gle/graph.cpp
@@ -1909,6 +1909,7 @@ public:
 	string comment;
 	string delimiters;
 	unsigned int ignore;
+	unsigned int numrows;
 	bool nox;
 };
 
@@ -1931,20 +1932,22 @@ unsigned int GLEDataSetDescription::getNrDimensions() const {
 }
 
 GLEDataDescription::GLEDataDescription() :
-    comment("!"),
-    delimiters(" ,;\t"),
+	comment("!"),
+	delimiters(" ,;\t"),
 	ignore(0),
+	numrows(0), // 0 ... unlimited
 	nox(false)
 {
 }
 
-/* data a.dat												  */
-/* data a.dat d2 d5											*/
-/* data a.dat d1=c1,c3 d2=c5,c1						  */
-/* data a.dat IGNORE n d2 d5							  */
-/* data a.dat IGNORE n d1=c1,c3 d2=c5,c1			  */
-/* data a.dat COMMENT # d1=c1,c3 d2=c5,c1				*/
-/* data a.dat COMMENT # IGNORE n d1=c1,c3 d2=c5,c1	*/
+/* data a.dat                                                */
+/* data a.dat d2 d5                                          */
+/* data a.dat d1=c1,c3 d2=c5,c1                              */
+/* data a.dat IGNORE n d2 d5                                 */
+/* data a.dat IGNORE n d1=c1,c3 d2=c5,c1                     */
+/* data a.dat COMMENT # d1=c1,c3 d2=c5,c1                    */
+/* data a.dat COMMENT # IGNORE n d1=c1,c3 d2=c5,c1           */
+/* data a.dat COMMENT # IGNORE n NUMROWS m d1=c1,c3 d2=c5,c1 */
 
 void read_data_description(GLEDataDescription* description, GLESourceLine& sline) {
 	// Get data command
@@ -1967,6 +1970,8 @@ void read_data_description(GLEDataDescription* description, GLESourceLine& sline
 		// check if it is one of the options
 		if (str_i_equals(token, "IGNORE")) {
 			description->ignore = tokens->next_integer();
+		} else if (str_i_equals(token, "NUMROWS")) {
+			description->numrows = tokens->next_integer();
 		} else if (str_i_equals(token, "COMMENT")) {
 			parser->evalTokenToFileName(&description->comment);
 		} else if (str_i_equals(token, "DELIMITERS")) {
@@ -2091,6 +2096,7 @@ void data_command(GLESourceLine& sline) {
 	csvData.setDelims(description.delimiters.c_str());
 	csvData.setCommentIndicator(description.comment.c_str());
 	csvData.setIgnoreHeader(description.ignore);
+	csvData.setNumrows(description.numrows);
 	csvData.read(expandedName);
 	unsigned int dataColumns = csvData.validateIdenticalNumberOfColumns();
 	GLECSVError* error = csvData.getError();


### PR DESCRIPTION
Commit will add new optional ```NUMROWS``` parameter to ```data``` command in ```graph``` block.
This parameter limits the number of parsed lines.
Code:
```
data filename.dat d1 ignore 3 numrows 3
```
will read only lines 4–6 from file ```filename.dat``` into dataset ```d1```.