### PR TITLE
Let inittex.ini be created when DESTDIR is used

### DIFF
--- a/src/TeX/CMakeLists.txt
+++ b/src/TeX/CMakeLists.txt
@@ -52,7 +52,7 @@ install(FILES
 )
 # make the inittex.ini in the install folder
 install(CODE
-	"execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/bin/gle$<$<CONFIG:Debug>:d> -mkinittex)"
+	"execute_process(COMMAND \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/gle$<$<CONFIG:Debug>:d> -mkinittex)"
 )
 
 


### PR DESCRIPTION
This solves one of the problems mentioned in #10—the one that inittex.ini isn't created if the installation is staged using `DESTDIR`.

It does not solve the other problem in #10—that `gle -mkinittex` crashes when it cannot open the file for writing.