### PR TITLE
Reserved identifiers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,8 +298,6 @@ if(APPLE)
 endif()
 if(UNIX AND NOT APPLE)
 	add_compile_definitions(
-		__LINUX__
-		UNIX
 		__UNIX__
 		HAVE_CONFIG_H
 		HAVE_CAIRO

--- a/src/gle/surface/ffitcontour.cpp
+++ b/src/gle/surface/ffitcontour.cpp
@@ -41,17 +41,9 @@
 	-lF77 -lI77 -lm -lc   (in that order)
 */
 
-/* "f2c.h" defines abs() -- conflict with the definition in <math.h> */
-/* changing the order solves the problem */
-#if ( defined(__OS2__) && defined(__EMX__) ) || defined(__WIN32__) || defined(__MAC__) || defined(__LINUX__)
 #include <stdio.h>
 #include <math.h>
 #include "f2c.h"
-#else
-#include <stdio.h>
-#include <math.h>
-#include "f2c.h"
-#endif
 
 doublereal gutre2_(real* a, real* b);
 void gd_message__(const char *s, int l);


### PR DESCRIPTION
Remove the only use of the `__LINUX__` macro and stop defining the now-unused `__LINUX__` and `UNIX` macros. See #14.