### PR TITLE
Fix typos in comments, messages, help pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ More information and the binary distributions can be found on the GLE website he
 
 ## Building with CMAKE
 
-GLE can be built on Windows, Mac, and Linux using cmake and system specific toolchains: Visual Studio, Xcode, and gcc.
+GLE can be built on Windows, macOS, and Linux using cmake and system specific toolchains: Visual Studio, Xcode, and gcc.
 
 Libraries needed to build GLE are
 
@@ -34,12 +34,12 @@ Cmake uses find_package or find_library to resolve the paths for these libraries
 * GHOSTPDL_ROOT
 * Qt5_DIR
 
-### Building on linux or OSX
+### Building on Linux or macOS
 
 	cmake -S src -B build
 	cd build ; make
 
-to install gle on you machine after building
+to install gle on your machine after building
 
 	cd build ; make install
 

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -61,11 +61,11 @@
     - updated manual to include new constants and special functions and grouped functions according to type. See appendix.
 
 4.3.0 (December 2020)
-    OSX, Linux and Windows 64 bit versions
+    macOS, Linux and Windows 64 bit versions
     built against QT5
 
 4.3.0 (November 2020)
-    OSX, Linux and Windows 64 bit versions
+    macOS, Linux and Windows 64 bit versions
     built against QT4
 
 4.3.0 (October 2020)
@@ -194,7 +194,7 @@ Bug Fixes
 
     #3058793: y1axis dominates the plot (lin/log) bound to y2axis
     #2782744: Automatic tick labels with latex
-    Fixed compilation on Mac OS/X
+    Fixed compilation on Mac OS X
     The graph block's "data" command now understands column c0, which contains the data set's line numbers
     #2996854: Missing a few multiple bars
     Fixed: xend()/yend() do not work in QGLE's edit mode
@@ -297,7 +297,7 @@ New Features
     New key block setting: "background", which sets the background color.
     Key box is now transparent (only for keys defined within the graph block).
     Adds function "atan2" (#1881021).
-    QGLE is now available on MacOS/X (installation instructions).
+    QGLE is now available on Mac OS X (installation instructions).
     "File | Edit" menu added to QGLE for easy access to files included in GLE script.
     "Edit | Copy as Bitmap" menu added to copy the diagram to the clipboard.
     Adds entries to QGLE's help menu to display the GLE manual and website.
@@ -534,12 +534,12 @@ Detailed Changes
     Includes makefiles for OS/2.
     Fix for slow rendering of long complex paths in postscript file. Speed now equivalent to 3.3h.
     Tweak to exe and src release filenames i.e gle_version_[src,exe]_[platform]....
-    Exits gracefully when it cant open a file such as a data file in graph, image file, include file or using fopen.
+    Exits gracefully when it can't open a file such as a data file in graph, image file, include file or using fopen.
 
 4.0.5 (November, 2003)
 
     Fix unix/linux compile issues with afm files. They now have the proper line endings for Unix.
-    Fix compatability issue with 3.3h: ATN and ATAN now work equivalently. In 3.3h only ATN worked for arctangent?
+    Fix compatibility issue with 3.3h: ATN and ATAN now work equivalently. In 3.3h only ATN worked for arctangent?
 
 4.0.4 (November, 2003)
 
@@ -547,7 +547,7 @@ Detailed Changes
     Will search c:\program files\gle (WINDOWS) or \usr\local\bin (UNIX) directories if GLE_TOP environment variable is not set.
     Proper wildcard/globbing handling on UNIX (assumes shell does the expansion).
     Minor improvement on file finding and error reporting.
-    Cleanup of unused functions and varibles in gle.cpp.
+    Cleanup of unused functions and variables in gle.cpp.
     Windows binary now compressed with upx.
 
 4.0.3 (November, 2003)
@@ -568,7 +568,7 @@ Detailed Changes
     Code cleanup from 3.5.
     Compiles with latest C++ compilers.
     Has better error reporting where it prints out the line number and text associated with the line (even if the error was detected in an include file).
-    Removed ncurses dependancy.
+    Removed ncurses dependency.
 
 GLE 3.3g (14-May-1994)
 
@@ -594,7 +594,7 @@ GLE 3.3f (16-April-1993)
 GLE 3.3e (1-Jan-1993)
 
     Fixed clipping of lines through a log axis.
-    Fixed help display which was loosing two lines on multi page
+    Fixed help display which was losing two lines on multi page
     displays.
 
 GLE 3.3d
@@ -608,7 +608,7 @@ GLE 3.3c (1-Apr-1992)
     Fixed problems with large datasets in surface and contour
     Fixed problem with /kern/lower/movexy and other def's
     Fixed bug with   dviprint -depson -hires -nosquash
-    Fixed bug with smoothing contours which made lines dissappear.
+    Fixed bug with smoothing contours which made lines disappear.
     (20-Sep-1992)
     Fixed bug with UNTIL looping.
     Removed limit of number of 'saved' points.

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -3,7 +3,7 @@ GLE Readme
 
 This document contains instructions on how to compile, install, and run GLE.
 
-Supported platforms: Windows, Linux, Mac OS/X, Unix, OS/2.
+Supported platforms: Windows, Linux, macOS, Unix, OS/2.
 
 Contents
 --------
@@ -14,7 +14,7 @@ Contents
 2.2 Installing GLE on OS/2
 3. Running GLE
 4. Compiling GLE from the source code
-4.1 Compiling with GCC (Windows, Linux, Mac OS/X, ...)
+4.1 Compiling with GCC (Windows, Linux, macOS, ...)
 4.2 Compiling on Windows (with Microsoft Visual C++)
 4.3 Compiling on OS/2 (with GCC 3.2.1)
 4.4 Notes for all platforms
@@ -149,7 +149,7 @@ and for Linux here:
 
 The GLE source code is distributed as gle-graphics-x.y.z-src.tar.gz.
 
-4.1 Compiling with GCC (Windows, Linux, Mac OS/X, ...)
+4.1 Compiling with GCC (Windows, Linux, macOS, ...)
 ------------------------------------------------------
 
 To install GLE system-wide:
@@ -238,7 +238,7 @@ Note: If you get the following error:
 The compilation process will built:
 
 gle(.exe) : GLE main executable
-fbuild(.exe) : makes *.fve fron *.gle using fbuild in the src\font directory
+fbuild(.exe) : makes *.fve from *.gle using fbuild in the src\font directory
 makefmt(.exe) : makes font files *.fmt from *.afm in the src\font directory
 
 It will also run the fbuild and makefmt commands and put the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../doc/LICENSE.txt"
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/../doc/README.txt")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "GLE")
 #
-# - NSIS specifc settings
+# - NSIS specific settings
 #
 set(CPACK_NSIS_COMPRESSOR "lzma")
 set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/gui/images\\gle.ico")
@@ -119,7 +119,7 @@ find_package(Boost)
 find_package(ZLIB)
 find_package(JPEG)
 find_package(TIFF)
-# find optional pacakges for LibTIFF
+# find optional packages for LibTIFF
 find_package(LibLZMA) # -- for libTIFF optional
 find_package(JBIG) # -- for libtiff optional
 if(JBIG_FOUND)

--- a/src/fonts/CMakeLists.txt
+++ b/src/fonts/CMakeLists.txt
@@ -2,7 +2,7 @@
 # -- font files - create .fve and .afm files for packaging with binary executable
 #
 # .fve file are created from .gle files of the same name using fbuild
-# .afm files are creted frin .fmt files using makefmt
+# .afm files are created frin .fmt files using makefmt
 #
 # all targets (.fve and .afm) files are put in the same /font folder in the distro
 #
@@ -265,7 +265,7 @@ file(MAKE_DIRECTORY ${OUTPUT_DIR})
 #add_custom_target(
 	#create_font_dir ALL
 	#COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTPUT_DIR}
-	#COMMENT "makeing font dir"
+	#COMMENT "making font dir"
 #)
 
 add_custom_target(fonts ALL

--- a/src/gle/begin.h
+++ b/src/gle/begin.h
@@ -38,7 +38,7 @@
 
 #ifndef INCLUDE_BEGIN
 #define INCLUDE_BEGIN
-extern int **gpcode;   /* gpcode is a pointer to an array of poiter to int */
+extern int **gpcode;   /* gpcode is a pointer to an array of pointer to int */
 extern int *gplen;     /* gpcode is a pointer to an array of int */
 extern int ngpcode;
 

--- a/src/gle/config.cpp
+++ b/src/gle/config.cpp
@@ -668,7 +668,7 @@ bool do_load_config(const char* appname, char **argv, CmdLineObj& cmdline, Confi
 				StripPathComponents(&GLE_TOP_DIR, 2);
 			#endif
 		} else {
-			// The user will see as error messege: "$GLE_TOP/some_file" not found.
+			// The user will see as error message: "$GLE_TOP/some_file" not found.
 			GLE_TOP_DIR = "$GLE_TOP";
 		}
 	} else {

--- a/src/gle/core.cpp
+++ b/src/gle/core.cpp
@@ -2073,7 +2073,7 @@ void g_postscript(char *fname, double wx, double wy) {
 	}
 	if (fabs(wy) < 1e-18) {
 		if (fabs(wx) < 1e-18) {
-			// if with and hight is zero, then use default size
+			// if width and height are zero, then use default size
 			wx = bx2/PS_POINTS_PER_INCH*CM_PER_INCH;
 			wy = by2/PS_POINTS_PER_INCH*CM_PER_INCH;
 		} else {

--- a/src/gle/cutils.cpp
+++ b/src/gle/cutils.cpp
@@ -79,13 +79,13 @@ static inline int isinf_ld (long double x) { return isnan (x - x); }
 
 int gle_isnan(double v) {
 	// Do not include <iostream> or <cmath> before gle_isnan
-	// otherwise gle_isnan wil break on Mac OS/X and OS/2
+	// otherwise gle_isnan will break on macOS and OS/2
 	return isnan(v);
 }
 
 int gle_isinf(double v) {
 	// Do not include <iostream> or <cmath> before gle_isinf
-	// otherwise gle_isinf wil break on Mac OS/X and OS/2
+	// otherwise gle_isinf will break on macOS and OS/2
 	return isinf(v);
 }
 

--- a/src/gle/d_ps.cpp
+++ b/src/gle/d_ps.cpp
@@ -61,7 +61,7 @@
 #define dbg if ((gle_debug & 64)>0)
 
 //
-// elipse function only for PS
+// ellipse function only for PS
 //
 static char ellipse_fcn[] = "\
 /ellipsedict 8 dict def\n ellipsedict /mtrx matrix put \n\
@@ -255,7 +255,7 @@ void PSGLEDevice::closedev() {
 		// - add to .Xresources: Ghostscript*geometry:   -5+0
 		//   to place gs window in upper right corner like  gle -d x11
 		// - may use environment variable or .glerc file for additional gs options
-		//   based on $DISPLAY, if you work on multiple sytems
+		//   based on $DISPLAY, if you work on multiple systems
 		if (GS_PREVIEW) {
 			ostringstream GScmd;
 			double width, height;
@@ -987,7 +987,7 @@ void PSGLEDevice::resetfont() {
 }
 
 void PSGLEDevice::read_psfont(void) {
-	/* add aditional ps fonts,  e.g.  pstr = TimesRoman */
+	/* add additional ps fonts,  e.g.  pstr = TimesRoman */
 	static int init_done;
 	FILE *fptr;
 	char *s;
@@ -1000,7 +1000,7 @@ void PSGLEDevice::read_psfont(void) {
 
 	string fname = fontdir("psfont.dat");
 	fptr = fopen(fname.c_str(), "r");
-	if (fptr == 0) return; /* if not exists then don't bother */
+	if (fptr == 0) return; /* if it doesn't exist then don't bother */
 
 	if (fgets(inbuff, 200, fptr) != 0) {
 		while (!feof(fptr)) {

--- a/src/gle/drawit.cpp
+++ b/src/gle/drawit.cpp
@@ -61,7 +61,7 @@
 extern int gle_debug;
 extern int this_line;
 int trace_on;
-int **gpcode;   /* gpcode is a pointer to an array of poiter to int */
+int **gpcode;   /* gpcode is a pointer to an array of pointer to int */
 int *gplen;     /* gpcode is a pointer to an array of int */
 int ngpcode=0;
 int ngerror;

--- a/src/gle/eval.cpp
+++ b/src/gle/eval.cpp
@@ -1239,7 +1239,7 @@ void debug_polish(int *pcode,int *zcp)
 	}
 	plen = *(pcode+*(cp));
 	gprint("Expression length %d current point %d \n",plen,(int) *cp);
-	if (plen>1000) gprint("Expession is suspiciously int %d \n",plen);
+	if (plen>1000) gprint("Expression is suspiciously int %d \n",plen);
 	for (c=(*cp)+1;(c-*cp)<=plen;c++) {
 	  cde = *(pcode+c);
 	  gprint("Code=%d ",cde);

--- a/src/gle/fn.cpp
+++ b/src/gle/fn.cpp
@@ -41,7 +41,7 @@
 #include "fn.h"
 
 /*-------------------------------------------------------------------*/
-/*      Find the function called *cp, and return it's number         */
+/*      Find the function called *cp, and return its number          */
 /*-------------------------------------------------------------------*/
 
 /* You can add a function, you MUST place it in alphabetical order   */

--- a/src/gle/gle-interface/gle-interface.h
+++ b/src/gle/gle-interface/gle-interface.h
@@ -74,7 +74,7 @@
 #ifndef _MSC_VER
 #define DLLFCT DLLIMPORT
 #else
-// in msvc  class function delcared as ddlimport or export do not need to be declared dllepxort or dllimport
+// in msvc  class functions declared as ddlimport or export do not need to be declared dllepxort or dllimport
 #define DLLFCT
 #endif
 #define DLLCLASS DLLCLASSIMPORT
@@ -82,7 +82,7 @@
 #ifndef _MSC_VER
 #define DLLFCT DLLEXPORT
 #else
-// in msvc  class function delcared as ddlimport or export do not need to be declared dllepxort or dllimport
+// in msvc  class functions declared as ddlimport or export do not need to be declared dllepxort or dllimport
 #define DLLFCT
 #endif
 #define DLLCLASS DLLCLASSEXPORT

--- a/src/gle/gle-sourcefile.cpp
+++ b/src/gle/gle-sourcefile.cpp
@@ -201,7 +201,7 @@ void GLESourceFile::reNumber() {
 }
 
 void GLESourceFile::load(istream& input) {
-	//  load the input and rememeber to look for continuation character
+	//  load the input and remember to look for continuation character
 	const char CONT_CHAR = '&';  // should be a global define somewhere??
 	bool cont = false;
 	string inbuff;

--- a/src/gle/gle.cpp
+++ b/src/gle/gle.cpp
@@ -380,7 +380,7 @@ void process_option_args(CmdLineObj& cmdline, GLEOptions& options) {
 			}
 		}
 	}
-	// Distable TeX interface
+	// Disable TeX interface
 	if (cmdline.hasOption(GLE_OPT_SAFEMODE)) {
 		TeXInterface* interface = TeXInterface::getInstance();
 		interface->setEnabled(false);
@@ -1141,7 +1141,7 @@ void GLELoadOneFileManager::delete_original_eps_pdf_impl(int deviceCode) {
 	bool should_del = hasFile(deviceCode);
 	if (device->hasValue(deviceCode)) {
 		/* don't delete .eps/.pdf if we wanted this as output */
-		/* and we did not wanted this printed to stout */
+		/* and we did not want this printed to stdout */
 		if (!m_OutName->isStdout() && !m_CmdLine->hasOption(GLE_OPT_CREATE_INC)) {
 			should_del = false;
 		}

--- a/src/gle/graph2.cpp
+++ b/src/gle/graph2.cpp
@@ -2715,7 +2715,7 @@ void GLELet::parseFitFunction(const string& fct, GLEParser* parser) {
 			setHasStepOption(true);
 			setStep(parser->evalTokenToDouble());
 		} else if (str_i_equals(token, "LIMIT_DATA_X")) {
-			// user wants the data ploted from dd xmax to dd xmin
+			// user wants the data plotted from dd xmax to dd xmin
 			m_limitDataX = true;
 		} else if (str_i_equals(token, "LIMIT_DATA_Y")) {
 			// get x values from evaluation of slope
@@ -3226,7 +3226,7 @@ void next_svg_iter(int* s, int* ct) {
 				polish_eval(next,&temp);
 				*s = (int) temp;
 			} else {
-				// its not a variable must be another keyword
+				// it's not a variable; must be another keyword
 				// set iter to 1
 				(*ct)--;
 				*s = 1;

--- a/src/gle/keyword.cpp
+++ b/src/gle/keyword.cpp
@@ -41,7 +41,7 @@
 #include "keyword.h"
 
 /*------------------------------------------------------------------*/
-/*      Find the KEY WORD *cp, and return it's number               */
+/*      Find the KEY WORD *cp, and return its number                */
 /*------------------------------------------------------------------*/
 /*                                                                  */
 /* You can add a function, you MUST place it in alphabetical order  */

--- a/src/gle/mem_limits.h
+++ b/src/gle/mem_limits.h
@@ -36,10 +36,10 @@
  *                                                                      *
  ************************************************************************/
 
-#ifndef INCLUDE_MEM_LIMTS
-#define INCLUDE_MEM_LIMTS
+#ifndef INCLUDE_MEM_LIMITS
+#define INCLUDE_MEM_LIMITS
 //
-// mem_limts.h
+// mem_limits.h
 //
 /*
  memory limits for GLE.
@@ -47,12 +47,12 @@
  these are all statically defined arrays, soon they will be replaced with STL
  containers
 
-These is gleaned from the file var.c
+These are gleaned from the file var.c
 
 also I had to modify the files sub.c polish.c eval.c to
 include LOCAL_START_INDEX
 
-it seems that all the commands,functions and variables are indexed by one variable
+it seems that all the commands, functions and variables are indexed by one variable
 
 if the index is > LOCAL_START_INDEX then it is treated as a local variable
 and stored in the lvar_name and lvar_val
@@ -84,10 +84,10 @@ else the variable is a global variable
 
 //
 // maximum element in the postscript line.  This affects speed of
-// PS rendereing.  any line that has more than
+// PS rendering.  any line that has more than
 // MAXIMUM_PS_VECTOR points in it will be broken up
 // into lines of MAXIMUM_PS_VECTOR
-// not this is assinged to MAX_VECTOR in gle.cpp
+// note this is assigned to MAX_VECTOR in d_ps.cpp
 // no warning is printed if this is exceeded as was done in 3.3h
 //
 #define MAXIMUM_PS_VECTOR 500

--- a/src/gle/mychar.cpp
+++ b/src/gle/mychar.cpp
@@ -37,8 +37,8 @@
  ************************************************************************/
 
 /*----------------------------------------------------------------------*/
-/* This routine prints a char from one of my fonts, it has cacheing 	*/
-/* for the char data, which could be extended to bitmap cacheing 	*/
+/* This routine prints a char from one of my fonts. It has caching	*/
+/* for the char data, which could be extended to bitmap caching.	*/
 /*----------------------------------------------------------------------*/
 
 #include "all.h"

--- a/src/gle/numberformat.cpp
+++ b/src/gle/numberformat.cpp
@@ -54,7 +54,7 @@
 
 	round 3
 	round number to 3 significant digits
-	pad with zeros if number too large (don't use exponential represenations)
+	pad with zeros if number too large (don't use exponential representations)
 
 	nozeros
 

--- a/src/gle/pass.cpp
+++ b/src/gle/pass.cpp
@@ -697,7 +697,7 @@ int GLEParser::get_optional(OPKEY lkey, GLEPcode& pcode) {
 	get_key_info(lkey, &count, &width);
 	// the location in the pcode tells what option it is, must remember
 	// zero all the optional parameters.
-	// puts zero in for each option wheather it is there or not
+	// puts zero in for each option whether it is there or not
 	int plen = pcode.size();
 	for (int i = 0; i < width+1; i++) {
 		pcode.addInt(0);
@@ -960,7 +960,7 @@ void GLEParser::get_color(GLEPcode& pcode) {
 }
 
 int get_marker_string(const string& marker, IThrowsError* error) {
-	/* if 0, maybe its a user defined marker, ie a subroutine */
+	/* if 0, maybe it's a user-defined marker, i.e. a subroutine */
 	/* Use -ve to signify subroutine instead of normal marker */
 	int mark_idx = 0;
 	for (int i = 0; i < nmark; i++) {

--- a/src/gle/polish.cpp
+++ b/src/gle/polish.cpp
@@ -205,7 +205,7 @@ void GLEPolish::internalPolish(GLEPcode& pcode, int *rtype) {
 			unary = 2;
 			pcode.erase(pcode.end() - 1);
 			pcode.erase(pcode.end() - 1);
-			savelen = -1; // lenght set from calling code
+			savelen = -1; // length set from calling code
 			//cout <<token<<endl;
 		}
 		dbg gprint("First word token via (1=unary %d) cts {%s}\n ", unary, token.c_str());

--- a/src/gle/run.cpp
+++ b/src/gle/run.cpp
@@ -63,7 +63,7 @@ void name_get2(char *n,double *x1,double *y1,double *x2,double *y2);
 extern OPKEY op_begin;
 extern GLESubMap g_Subroutines;
 
-extern int **gpcode;   /* gpcode is a pointer to an array of poiter to int */
+extern int **gpcode;   /* gpcode is a pointer to an array of pointer to int */
 extern int *gplen;     /* gpcode is a pointer to an array of int */
 
 string get_b_name(int jj) {

--- a/src/gle/sub.cpp
+++ b/src/gle/sub.cpp
@@ -48,7 +48,7 @@
 #include "glearray.h"
 #include "polish.h"
 
-extern int **gpcode;   /* gpcode is a pointer to an array of poiter to int */
+extern int **gpcode;   /* gpcode is a pointer to an array of pointer to int */
 extern int *gplen;     /* gpcode is a pointer to an array of int */
 extern int ngpcode;
 extern int gle_debug;

--- a/src/gle/surface/fcontour.cpp
+++ b/src/gle/surface/fcontour.cpp
@@ -251,7 +251,7 @@ integer iget_(huge integer *bitmap, integer *n)
 
 /*     zmax is the maximum value of z for consideration.  a value of */
 /*     z(i,j) greater than zmax is a signal that that point and the */
-/*     grid line segments radiating from that point to it's neighbors */
+/*     grid line segments radiating from that point to its neighbors */
 /*     are to be excluded from contouring. */
 
 /*     bitmap is a work area large enough to hold 2*nx*ny*ncv bits.  it */
@@ -315,11 +315,11 @@ integer iget_(huge integer *bitmap, integer *n)
 
 /*     l1 and l2 contain limits used during the spiral search for the */
 /*     beginning of a contour. */
-/*     ij stores subcripts used during the spiral search. */
+/*     ij stores subscripts used during the spiral search. */
 
 
 /*     i1, i2 and i3 are used for subscript computations during the */
-/*     examination of lines from z(i,j) to it's neighbors. */
+/*     examination of lines from z(i,j) to its neighbors. */
 
 
 /*     xint is used to mark intersections of the contour under */

--- a/src/gle/tex.cpp
+++ b/src/gle/tex.cpp
@@ -76,7 +76,7 @@
  *        text_draw
  *
  * text_tomacro
- *    -> expands macro's (starting with "\")
+ *    -> expands macros (starting with "\")
  *    -> expands special characters (such as '^' and '_') unless they are escaped
  *
  * text_topcode
@@ -182,7 +182,7 @@ deftable *tex_finddef(const char *s) ;
 int fontfam[16][4];
 double fontfamsz[16][4];        /* 1=text,  2=script, 3=scriptscript */
 int famdef = -1;        /* don't use unless/until it is defined */
-char *cdeftable[256];   /* Character macro's */
+char *cdeftable[256];   /* Character macros */
 uchar chr_code[256];    /* Character codes 1..9  */
 int chr_mathcode[256];  /* Character codes 1..9  */
 int chr_init;           /* Flag to initialize chr variables */
@@ -354,7 +354,7 @@ norm_again:
 		outlong(0);             /* space for x,y to be put */
 		outlong(0);
 		break;
-	    case 6: /* \ Primitive Command (macro's already done) */
+	    case 6: /* \ Primitive Command (macros already done) */
 		skip_space = false;
 		do_prim(&in,out,lout,&params);
 		break;
@@ -393,7 +393,7 @@ norm_again:
 
 uchar* cmdParam(uchar **inp, uchar **pm, int* pmlen, int npm) {
 	int gcnt=0,i;
-	uchar* save_inp = *inp; /* need this to look ahead but not move ahaead */
+	uchar* save_inp = *inp; /* need this to look ahead but not move ahead */
 	uchar* in = *inp;
 	gcnt = 0;
 	for (i=0;i<npm;i++) {
@@ -757,7 +757,7 @@ void do_prim(uchar **in, int *out, int *lout, TexArgStrs* params) {
 	cmd_token(in,cmdstr);   /* finds command name and parameters */
 	ci = find_primcmd((char*)cmdstr);
 
-	if (ci==0) { /* then maybe its a mathchar */
+	if (ci==0) { /* then maybe it's a mathchar */
 		m = tex_findmathdef((char*)cmdstr);
 		if (m!=0) {
 			p_mathchar(*m);
@@ -1854,9 +1854,9 @@ void  text_tomacro(const string& in, uchar *out) {
 				s = UC str_skip_brackets((char*)s, '{', '}');
 			}
 			if (strcmp((char*)macroname, "def")==0) {
-				// make sure not to expand macro's in macro name
+				// make sure not to expand macros in macro name
 				// otherwise, during a second pass, the name will be replaced by the value
-				// e.g., \def\a{b} will trun into: \defb{b{}
+				// e.g., \def\a{b} will turn into: \defb{b{}
 				s = UC str_find_char((const char*)s, '{');
 			}
 		}

--- a/src/gle/tokens/StringKeyHash.h
+++ b/src/gle/tokens/StringKeyHash.h
@@ -76,7 +76,7 @@ using namespace std;
 
 #ifndef GCC2
 #ifndef _MSC_VER
-	// gcc on OSX is complaining about this not sure if its needed
+	// gcc on macOS is complaining about this; not sure if it's needed
 	// using namespace __gnu_cxx;  // using gnu extensions such as "hash"
 #endif
 #endif

--- a/src/gle/tokens/Tokenizer.h
+++ b/src/gle/tokens/Tokenizer.h
@@ -373,7 +373,7 @@ public:
 	int is_next_token(const string& token) {
 		return is_next_token(token.c_str());
 	}
-	// checks wether next token is [token].  if so, the token is
+	// checks whether next token is [token].  if so, the token is
 	// consumed (current token pointer moved).   Otherwise,
 	// the next token is not consumed.
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -130,7 +130,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(APPLE)
-	#openGL is deprecated on OSX starting 10.9 this silences the warning
+	#openGL is deprecated on macOS starting at 10.9; this silences the warning
 	add_compile_definitions(Q_OS_APPLE)
 	add_compile_options(-Wno-deprecated-declarations)
 	target_link_libraries ( qgle LINK_PUBLIC

--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -120,7 +120,7 @@ QWidget* AboutBox::createContributorsPanel()
 	"<li>Chris Pugmire: original program creation and design</li>"
 	"<li>Christoph Brendes: programming</li>"
 	"<li>David Parfitt: documentation (GLE users guide)</li>"
-	"<li>Edd Edmondson: packager for Mac OS/X"
+	"<li>Edd Edmondson: packager for macOS"
 	"<li>Jan Struyf: programming (and current 4.x series maintainer)</li>"
 	"<li>Laurence Abbott: programming</li>"
 	"<li>Michal Vyskocil: packager for openSUSE</li>"

--- a/src/gui/dialogues.cpp
+++ b/src/gui/dialogues.cpp
@@ -435,7 +435,7 @@ void SoftwareLocateDialogue::locateManual() {
 	cursor.movePosition(QTextCursor::End);
 	browser->setTextCursor(cursor);
 	browser->insertPlainText(tr("\n"));
-	// don't use stock dialog; otherwise it's impossible to select a framework on MacOS/X
+	// don't use stock dialog; otherwise it's impossible to select a framework on macOS
 	QFileDialog dialog(this, tr("Locate the GhostScript library"), "/", QGLE::libraryFilter());
 	dialog.setFileMode(QFileDialog::AnyFile);
 	if (dialog.exec()) {

--- a/src/gui/gledrawing.cpp
+++ b/src/gui/gledrawing.cpp
@@ -132,7 +132,7 @@ void GLEDrawingArea::initSelectionVars()
 	isSelectedObjectSnap = false;
 	// Selection handles
 	handleList.clear();
-	// Used for rotating objectss
+	// Used for rotating objects
 	baseAngle = 0.0;
 	lastAngle = 0.0;
 	// Reference point for scale / move

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -563,7 +563,7 @@ void GLEMainWindow::startServer()
 	connect(serverThread, SIGNAL(serverMessage(QString)),
 			this, SLOT(updateServerStatus(QString)));
 
-	// Notify QGLE that a new file has been opended using "gle -p"
+	// Notify QGLE that a new file has been opened using "gle -p"
 	connect(serverThread, SIGNAL(gleMinusPRunned(QString)),
 			this, SLOT(openFile(QString)));
 

--- a/src/gui/qgle_statics.cpp
+++ b/src/gui/qgle_statics.cpp
@@ -138,7 +138,7 @@ void QGLE::qtToGLEString(const QString& str1, GLEString* str2) {
 	}
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::absGLEToQt(double gleX, double gleY, double dpi, int areaHeight)
 {
 	double qtX, qtY;
@@ -150,7 +150,7 @@ QPointF QGLE::absGLEToQt(double gleX, double gleY, double dpi, int areaHeight)
 	return(QPointF(qtX, qtY));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::absGLEToQt(QPointF gle, double dpi, int areaHeight)
 {
 	return(absGLEToQt(gle.x(), gle.y(), dpi, areaHeight));
@@ -174,7 +174,7 @@ QSizeF QGLE::qtSizeToGLE(QSizeF qt, double dpi)
 	return(QSizeF(gleX,gleY));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::relGLEToQt(double gleX, double gleY, double dpi)
 {
 	double qtX, qtY;
@@ -185,13 +185,13 @@ QPointF QGLE::relGLEToQt(double gleX, double gleY, double dpi)
 	return(QPointF(qtX, qtY));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::relGLEToQt(QPointF gle, double dpi)
 {
 	return(relGLEToQt(gle.x(), gle.y(), dpi));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QSizeF QGLE::relGLEToQt(QSizeF gle, double dpi)
 {
 	QPointF qt;
@@ -204,7 +204,7 @@ double QGLE::relGLEToQt(double gle, double dpi)
 	return(gle*dpi/CM_PER_INCH);
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::relQtToGLE(double qtX, double qtY, double dpi)
 {
 	double gleX, gleY;
@@ -215,13 +215,13 @@ QPointF QGLE::relQtToGLE(double qtX, double qtY, double dpi)
 	return(QPointF(gleX, gleY));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::relQtToGLE(QPointF qt, double dpi)
 {
 	return(relQtToGLE(qt.x(), qt.y(), dpi));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QSizeF QGLE::relQtToGLE(QSizeF qt, double dpi)
 {
 	QPointF gle;
@@ -234,7 +234,7 @@ double QGLE::relQtToGLE(double qt, double dpi)
 	return(qt*CM_PER_INCH/dpi);
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::absQtToGLE(double qtX, double qtY, double dpi, int areaHeight)
 {
 	double gleX, gleY;
@@ -245,7 +245,7 @@ QPointF QGLE::absQtToGLE(double qtX, double qtY, double dpi, int areaHeight)
 	return(QPointF(gleX, gleY));
 }
 
-// Static member used to convert betweeen coordinate systems
+// Static member used to convert between coordinate systems
 QPointF QGLE::absQtToGLE(QPointF qt, double dpi, int areaHeight)
 {
 	return(absQtToGLE(qt.x(), qt.y(), dpi, areaHeight));
@@ -355,7 +355,7 @@ double QGLE::min(double a, double b) {
 	return a < b ? a : b;
 }
 
-//! Static member comverting from centimeters to PostScript points
+//! Static member converting from centimeters to PostScript points
 double QGLE::cmToPt(double cm) {
 	return cm*PS_POINTS_PER_INCH/CM_PER_INCH;
 }

--- a/src/gui/qgle_statics.h
+++ b/src/gui/qgle_statics.h
@@ -167,7 +167,7 @@ public:
 
 	//! Static member used to compute the minimum of two double values
 	static double min(double a, double b);
-	//! Static member comverting from centimeters to PostScript points
+	//! Static member converting from centimeters to PostScript points
 	static double cmToPt(double cm);
 	//! Static member used to compute the DPI value based on the display and image size (in cm)
 	static int computeAutoScaleDPIFromCm(const QSize& bitmapSize, int inset, double imgWd, double imgHi);

--- a/src/gui/qgs.cpp
+++ b/src/gui/qgs.cpp
@@ -113,7 +113,7 @@ int rectangle_request(void *handle, void *device,void **memory, int *ox, int *oy
 }
 
 #ifdef USE_INTERNAL_GSAPI
-	// old gs api - depricated - 9.2 and earlier
+	// old gs api - deprecated - 9.2 and earlier
 	// will not work with newer gs that has V3
 	#define GS_ERROR(name) e_##name
 	#ifdef QGS_USE_MAJOR_V2
@@ -275,7 +275,7 @@ bool GSInterpreterLib::start(bool setStdio)
 		                                           &(GSApiWrapper::handleStdout),
 		                                           &(GSApiWrapper::handleStderr));
 	}
-	// depricated - use register_callout
+	// deprecated - use register_callout
 	//int call = m_gs->gsapi_set_display_callback(ghostScriptInstance, (display_callback*)(&(GSApiWrapper::device)));
 	int state = 0;
 	int call = m_gs->gsapi_register_callout(ghostScriptInstance, my_callout_handler, &state);

--- a/src/gui/qgs.h
+++ b/src/gui/qgs.h
@@ -107,7 +107,7 @@ public:
 	PFN_gsapi_delete_instance gsapi_delete_instance;
 	PFN_gsapi_set_stdio gsapi_set_stdio;
 	PFN_gsapi_set_poll gsapi_set_poll;
-	// used in g2 9.2 or earlier - depricated now 
+	// used in g2 9.2 or earlier - deprecated now
 	PFN_gsapi_set_display_callback gsapi_set_display_callback;
 	PFN_gsapi_register_callout gsapi_register_callout;
 	PFN_gsapi_init_with_args gsapi_init_with_args;
@@ -222,9 +222,9 @@ public:
 	void setGhostscriptArguments( const QStringList &list );
 
 	/** @brief Enable display setting
-	           This should be set to true if you are using the intepreter to render pages or in any way
+	           This should be set to true if you are using the interpreter to render pages or in any way
 	           need a display device in your use of the Ghostscript library. If you do not need it
-	           (ex. you are just converting ps to pdf) set it to false.
+	           (e.g. you are just converting ps to pdf) set it to false.
 	    @param display enable/disable the display device
 	*/
 	void setDisplay( bool display = true);

--- a/src/gui/readme.txt
+++ b/src/gui/readme.txt
@@ -101,7 +101,7 @@ make
 make install
 qgle
 
-Note that more information on comiling GLE can be found here:
+Note that more information on compiling GLE can be found here:
 <http://glx.sourceforge.net/tut/linux.html>
 
 On Arch Linux, the QT4 package lives in /opt/qt4 whereas QT3 lives in

--- a/src/gui/serverthread.h
+++ b/src/gui/serverthread.h
@@ -62,7 +62,7 @@ public:
 signals:
 	//! This signal keeps the user notified of what's going on.
 	void serverMessage(QString msg);
-	//! This signal notifies QGLE that a new file has been opended using "gle -p"
+	//! This signal notifies QGLE that a new file has been opened using "gle -p"
 	void gleMinusPRunned(QString file);
 
 protected:

--- a/src/gui/settings_dialogue.cpp
+++ b/src/gui/settings_dialogue.cpp
@@ -667,7 +667,7 @@ void ToolTab::exploreGLETop() {
 void ToolTab::browseToolGsLib() {
 	QString dir = QGLE::GetDirName(ToolGsLib->text());
 	if (dir.isEmpty()) dir = "/";
-	// don't use stock dialog; otherwise it's impossible to select a framework on MacOS/X
+	// don't use stock dialog; otherwise it's impossible to select a framework on macOS
 	QFileDialog dialog(this, tr("Locate the GhostScript library"), dir, QGLE::libraryFilter());
 	dialog.setFileMode(QFileDialog::AnyFile);
 	if (dialog.exec()) {

--- a/src/makefmt/parseAFM.cpp
+++ b/src/makefmt/parseAFM.cpp
@@ -6,7 +6,7 @@
  *   2) If the file has been modified in any way, a notice of such
  *      modification is conspicuously indicated.
  *
- * PostScript, Display PostScript, and Adobe are regsitered trademarks of
+ * PostScript, Display PostScript, and Adobe are registered trademarks of
  * Adobe Systems Incorporated.
  *
  * ************************************************************************
@@ -112,7 +112,7 @@ enum parseKey {
   NOPE };
 
 /* keywords for the system:
- * This a table of all of the current strings that are vaild AFM keys.
+ * This a table of all of the current strings that are valid AFM keys.
  * Each entry can be referenced by the appropriate parseKey value (an
  * enumerated data type defined above). If you add a new keyword here,
  * a corresponding parseKey MUST be added to the enumerated data type
@@ -1098,7 +1098,7 @@ static int parseCompCharData(FILE *fp, FontInfo *fi)
  *  The caller of this function is responsible for locating and opening
  *  an AFM file and handling all errors associated with that task.
  *
- *  parseFile expects 3 parameters: a vaild file pointer, a pointer
+ *  parseFile expects 3 parameters: a valid file pointer, a pointer
  *  to a (FontInfo *) variable (for which storage will be allocated and
  *  the data requested filled in), and a mask specifying which
  *  data from the AFM File should be saved in the FontInfo structure.

--- a/src/makefmt/parseAFM.h
+++ b/src/makefmt/parseAFM.h
@@ -64,7 +64,7 @@
  *
  * There is a procedure in parseAFM.c, called parseFile, that can be
  * called from any application wishing to get information from the AFM File.
- * This procedure expects 3 parameters: a vaild file descriptor, a pointer
+ * This procedure expects 3 parameters: a valid file descriptor, a pointer
  * to a (FontInfo *) variable (for which space will be allocated and then
  * will be filled in with the data requested), and a mask specifying
  * which data from the AFM File should be saved in the FontInfo structure.
@@ -123,7 +123,7 @@
  * parser went on. This could include problems like the count for any given
  * section does not add up to how many entries there actually were, or
  * there was a key that was not recognized. The return record may contain
- * vaild data or it may not.
+ * valid data or it may not.
  *
  * earlyEOF means that an End of File was encountered before expected. This
  * may mean that the AFM file had been truncated, or improperly formed.

--- a/src/manip/cmd.cpp
+++ b/src/manip/cmd.cpp
@@ -40,7 +40,7 @@
 	'string   - put string in cell and move in current direction
 	range = expression  - evaluate exp for each cell in range
 	cell(exp,exp) = expression  - evaluate exp and put in cell
-	cmd - exectue command, if then else next for save load generate
+	cmd - execute command, if then else next for save load generate
 				   print, input
 	& = continued on next line.
 

--- a/src/manip/eval.cpp
+++ b/src/manip/eval.cpp
@@ -103,7 +103,7 @@ void eval(int32 *pcode,int *cp,double *oval,char *ostr,int *otyp) {
 	}
 	plen = *(pcode+*(cp));
 	dbg gprint(" plen = %d ",plen);
-	if (plen>1000) gprint("Expession is suspiciously int32 %d \n",plen);
+	if (plen>1000) gprint("Expression is suspiciously int32 %d \n",plen);
 	for (c=(*cp)+1;c<=(plen+ *cp);c++) {
 	  switch (*(pcode+c)) {
 		/* Special commands 1..9  ------------------------------- */
@@ -381,7 +381,7 @@ void debug_polish(int32 *pcode,int *zcp) {
 	}
 	plen = *(pcode+*(cp));
 	gprint("Expression length %d current point %d \n",plen,(int) *cp);
-	if (plen>1000) gprint("Expession is suspiciously int %d \n",plen);
+	if (plen>1000) gprint("Expression is suspiciously int %d \n",plen);
 	for (c=(*cp)+1;(c-*cp)<=plen;c++) {
 	  cde = *(pcode+c);
 	gprint("Code=%d ",cde);

--- a/src/manip/filemenu.cpp
+++ b/src/manip/filemenu.cpp
@@ -135,7 +135,7 @@ int m_gstart,m_gend;
 char mbuff[255];
 
 extern int iserr;
-int hcx,cx,hcy;        /* HIlighted current x,y */
+int hcx,cx,hcy;        /* highlighted current x,y */
 
 bool do_menu(pmenutype *ppmenu) {
         menutype *cm,*cmi,*si=NULL,*mi;

--- a/src/manip/fn.cpp
+++ b/src/manip/fn.cpp
@@ -40,7 +40,7 @@
 #include "eval.h"
 
 /*------------------------------------------------------------------*/
-/*      Find the function callped *cp, and return it's number       */
+/*      Find the function callped *cp, and return its number        */
 /*------------------------------------------------------------------*/
 
 /* You can add a function, you MUST place it in alphabetical order  */

--- a/src/manip/keyword.cpp
+++ b/src/manip/keyword.cpp
@@ -40,7 +40,7 @@
 #include "keyword.h"
 
 /*------------------------------------------------------------------*/
-/*      Find the KEY WORD *cp, and return it's number       */
+/*      Find the KEY WORD *cp, and return its number                */
 /*------------------------------------------------------------------*/
 
 /* You can add a function, you MUST place it in alphabetical order  */

--- a/src/manip/manip.cpp
+++ b/src/manip/manip.cpp
@@ -606,7 +606,7 @@ void init_gle_top(char** argv) {
 				StripPathComponents(&GLE_TOP_DIR, 2);
 			#endif
 		} else {
-			// The user will see as error messege: "$GLE_TOP/some_file" not found.
+			// The user will see as error message: "$GLE_TOP/some_file" not found.
 			GLE_TOP_DIR = "$GLE_TOP";
 		}
 	} else {

--- a/src/manip/manip.hlp
+++ b/src/manip/manip.hlp
@@ -103,7 +103,7 @@
 
 3 ARROWS
  The arrow keys normally move the data cursor, however if you are half
- way througg typing a command then, the left and right arrow keys allow you
+ way through typing a command then the left and right arrow keys allow you
  to edit the command.  Use the PAGE-UP and PAGE-DOWN keys to recall
  your last command.
 
@@ -112,7 +112,7 @@
 3 COPY
  For copying a section to another section. "% COPY <range1> <range2> if <exp>"
  They do not have to be the same shape. The pointers to both rangers
- are increased even if the number is not coppied  e.g. 
+ are increased even if the number is not copied  e.g.
 	"% COPY r4r2 r1r2"
 	"% COPY c1c3r6r100  c6c8 if c1<c2"
 
@@ -126,7 +126,7 @@
 
 
 3 DELETE
- For deleteing entire rows or columns.  "% DELETE <range> [IF <exp>]"
+ For deleting entire rows or columns.  "% DELETE <range> [IF <exp>]"
  e.g. 	"% DELETE c1c3 IF r1>3.and.r2=0
 	"% DELETE r1"
  Numbers are shuffled in from the right to take the place of the
@@ -146,7 +146,7 @@
 
 3 EXIT 
  EXIT saves the data in your input file spec and exits to DOS.  You
- can optionally specify an output file as well. eg. "% EXIT myfile.dat
+ can optionally specify an output file as well e.g. "% EXIT myfile.dat
 
  The command "EXIT myfile.dat c3c5r1r3" will write out that range of
  numbers to the file.
@@ -213,17 +213,17 @@
  e.g. 	"% INSERT c5" or "% INSERT r2".
 
 3 LOAD
- Load data into columns. eg. "% LOAD filename" loads all data into corresponding
+ Load data into columns e.g. "% LOAD filename" loads all data into corresponding
  columns.  "% LOAD filename c3" load first column of data into c3 etc.
 
  "LOAD myfile.dat c3 -LIST"
- This commmand will load the the data into a single column or range
+ This command will load the the data into a single column or range
  (even if it is several columns wide in the data file)
 
 3 MOVE
  For copying a section to another section. "% MOVE <range1> <range2> if <exp>"
  They do not have to be the same shape. The pointer to the destination
- is only increased if the line or column is coppied e.g.
+ is only increased if the line or column is copied e.g.
 	"% MOVE c1 c2c3"
 	"% MOVE r4r2 r1r2"
 	"% MOVE c1c3r6r100  c6c8 if c1<c2"
@@ -326,7 +326,7 @@
   (See also SET COLTYPE) 
 
 4 DIGITS
-	Sets the number of significat digits to be displayed, e.g.
+	Sets the number of significant digits to be displayed, e.g.
 	with DIGITS 3.
 		123456    becomes   123000
 		0.12345   becomes   0.123
@@ -342,7 +342,7 @@
 3 PROPAGATE
  This command has the same format as move. e.g
  "% PROPAGATE <source> <destination>"  The difference is that the
- source is coppied as many times as possible to fill up the destination.
+ source is copied as many times as possible to fill up the destination.
  e.g. 	"% PROP c1r1r7 c2"
 
 3 SUM
@@ -350,18 +350,18 @@
 	"% SUM C1C3"
 
 3 PARSUM
- Adds up one coloumn, putting the partial sum's into another coloumn.e.g.
+ Adds up one column, putting the partial sums into another column. e.g.
  1,2,3,4 becomes 1,3,6,10.
 	"% PARSUM C1 C4"
 
 3 GENERATE
- For generating a patter of data e.g.   1 1 2 2 5 5 1 1 2 2 5 5 etc.
+ For generating a pattern of data e.g.   1 1 2 2 5 5 1 1 2 2 5 5 etc.
 	"% GEN 2(1,2,5)30 c4"	!1 1 2 2 5 5  repeated 30 times
 	"% GEN (1:100:5)5 c1"	!1 to 100 step 5,  5 times
 	"% GEN (1,2,*,3:5)5 c1"	!missing values included
 
 3 FUNCTIONS
- Calculations can be performed on rows or columns. eg "% C1=C2*3+R"
+ Calculations can be performed on rows or columns e.g. "% C1=C2*3+R"
  where "R" stands for row-number and C1 and C2 are columns.
  They can also be performed on ROWS. eg "% r1=sin(r2)+log10(c)"
 

--- a/src/manip/sub.cpp
+++ b/src/manip/sub.cpp
@@ -40,7 +40,7 @@
 
 int var_alloc_local(void);
 int var_free_local(void);
-extern int32 *(*gpcode)[];   /* gpcode is a pointer to an array of poiter to int32 */
+extern int32 *(*gpcode)[];   /* gpcode is a pointer to an array of pointer to int32 */
 extern int32 (*gplen)[];   /* gpcode is a pointer to an array of int32 */
 extern int ngpcode;
 extern int gle_debug;

--- a/src/manip/varargs.cpp
+++ b/src/manip/varargs.cpp
@@ -39,7 +39,7 @@
 /*
 
 As varargs are so difficult to make work, I've put them
-in this module by themselvs,  on a DEC5400 it was necessary
+in this module by themselves. On a DEC5400 it was necessary
 to compile this module using the native C compiler instead of
 GCC
 


### PR DESCRIPTION
This is the result of running [codespell](https://github.com/codespell-project/codespell/) plus some manual edits.