### PR TITLE
Link with libjpeg even on macOS and Windows

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -60,13 +60,7 @@ add_executable(qgle WIN32 MACOSX_BUNDLE
 list(APPEND QGLE_LIBRARIES
 	libgle-graphics_s
 	${ZLIB_LIBRARIES}
-)
-if(UNIX AND NOT APPLE)
-	list(APPEND QGLE_LIBRARIES
-	${JPEG_LIBRARIES} # contained in Qt on windows and MacOS
-	)
-endif()
-list(APPEND QGLE_LIBRARIES
+	${JPEG_LIBRARIES}
 	${PNG_LIBRARIES}
 	${PIXMAN_LIBRARIES}
 	TIFF::TIFF


### PR DESCRIPTION
src/gle/gle-poppler.cpp directly uses libjpeg functions so it must directly link with libjpeg. Fixes undefined jpeg symbol errors on macOS in some build configurations.

```
Undefined symbols for architecture x86_64:
  "_jpeg_CreateCompress", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_destroy_compress", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_finish_compress", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_set_defaults", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_start_compress", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_std_error", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
  "_jpeg_write_scanlines", referenced from:
      gle_write_cairo_surface_jpeg(_cairo_surface*, int, void (*)(void*, char*, int), void*) in libgle-graphics_s.a(gle-poppler.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

See #2