### PR TITLE
Fix parallel build by not copying gle.cpp anymore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
             jobs=1
         esac
 
-        # Remove this jobs=1 override once parallel building is fixed.
-        # See https://github.com/vlabella/GLE/issues/26
-        jobs=1
-
         echo "--parallel $jobs" >> build.args
     - name: Configure
       run: |

--- a/src/gle/CMakeLists.txt
+++ b/src/gle/CMakeLists.txt
@@ -79,14 +79,6 @@ set( GLEBTOOL_SOURCES
 )
 
 add_custom_command(
- 	OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/gle_cpp_lib.cpp
- 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gle.cpp
- 	COMMAND ${CMAKE_COMMAND} -E copy gle.cpp gle_cpp_lib.cpp
-  	COMMENT "Generating gle_cpp_lib.cpp from gle.cpp"
-  	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-add_custom_command(
  	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/glerc
  	COMMAND ${CMAKE_COMMAND} -E echo begin config gle > ${CMAKE_CURRENT_BINARY_DIR}/glerc
  	COMMAND ${CMAKE_COMMAND} -E echo current = ${PROJECT_VERSION} >> ${CMAKE_CURRENT_BINARY_DIR}/glerc
@@ -97,10 +89,11 @@ add_custom_command(
 
 add_library(gle_common OBJECT ${GLE_SOURCES})
 add_executable( gle $<TARGET_OBJECTS:gle_common> gle.cpp )
-add_library( gle-graphics_s STATIC $<TARGET_OBJECTS:gle_common> gle_cpp_lib.cpp )
-add_library( gle-graphics SHARED $<TARGET_OBJECTS:gle_common> gle_cpp_lib.cpp )
+add_library(gle-graphics_s STATIC $<TARGET_OBJECTS:gle_common> gle.cpp)
+add_library(gle-graphics SHARED $<TARGET_OBJECTS:gle_common> gle.cpp)
+target_compile_definitions(gle-graphics_s PRIVATE -DHAVE_LIBGLE)
+target_compile_definitions(gle-graphics PRIVATE -DHAVE_LIBGLE)
 add_custom_target( glerc_file ALL DEPENDS glerc )
-set_source_files_properties( gle_cpp_lib.cpp PROPERTIES COMPILE_FLAGS -DHAVE_LIBGLE)
 
 set_target_properties(gle PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 set_target_properties(gle-graphics_s PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})

--- a/src/gle/gle.cpp
+++ b/src/gle/gle.cpp
@@ -112,7 +112,7 @@ void gle_cat_csv(vector<string>* files) {
 	}
 }
 
-#if defined(HAVE_LIBGLE) || defined(HAVE_LIBGLE_STATIC)
+#ifdef HAVE_LIBGLE
 int GLEMain(int argc, char **argv) {
 #else
 int main(int argc, char **argv) {


### PR DESCRIPTION
When parallel building, copying gle.cpp to gle_cpp_lib.cpp could happen twice, once for the static library and once for the shared library, and this could conflict and cause a build error. The copy was only made so that different compile definitions could be attached to gle_cpp_lib.cpp. Instead, attach the compile definitions to the library targets.

Fixes #26

I removed the check for whether `HAVE_LIBGLE_STATIC` was defined because nothing in the build system ever defines that macro.